### PR TITLE
Override default transport for document requests

### DIFF
--- a/proxy/document_transport.go
+++ b/proxy/document_transport.go
@@ -1,0 +1,50 @@
+package proxy
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"regexp"
+)
+
+type bodyTransformation func(body io.ReadCloser, req *http.Request) (io.ReadCloser, error)
+
+func newDocumentTransport(inner http.RoundTripper) *documentTransport {
+	return &documentTransport{inner, replaceImagesURLProtocol()}
+}
+
+type documentTransport struct {
+	transport     http.RoundTripper
+	transformBody bodyTransformation
+}
+
+func (t *documentTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	res, err := t.transport.RoundTrip(req)
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := t.transformBody(res.Body, req)
+	if err != nil {
+		return nil, err
+	}
+
+	res.Body = body
+
+	return res, nil
+}
+
+var regex = regexp.MustCompile(`(?m)"url":"http(:[^"]+)"`)
+
+func replaceImagesURLProtocol() bodyTransformation {
+	return func(body io.ReadCloser, req *http.Request) (io.ReadCloser, error) {
+		content, err := ioutil.ReadAll(body)
+		if err != nil {
+			return nil, err
+		}
+		fixed := regex.ReplaceAllString(string(content), `"url":"https$1"`)
+
+		return ioutil.NopCloser(bytes.NewReader([]byte(fixed))), nil
+	}
+}

--- a/proxy/document_transport_test.go
+++ b/proxy/document_transport_test.go
@@ -1,0 +1,42 @@
+package proxy
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestDocumentTransport(t *testing.T) {
+	Convey("RoundTrip", t, func() {
+		Convey("transforms returned body", func() {
+			t := &documentTransport{
+				transport:     roundTripReturningBody(http.StatusOK, `"image":{"url":"http://my-fake-image.jpeg"}`),
+				transformBody: replaceImagesURLProtocol(),
+			}
+
+			// Act
+			res, err := t.RoundTrip(httptest.NewRequest("GET", "http://target.com", nil))
+
+			// Assert
+			So(err, ShouldBeNil)
+			body, _ := ioutil.ReadAll(res.Body)
+			So(string(body), ShouldEqual, `"image":{"url":"https://my-fake-image.jpeg"}`)
+		})
+	})
+
+}
+
+func roundTripReturningBody(statusCode int, body string) http.RoundTripper {
+	return &fakeRoundTripper{
+		roundTrip: func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				Header:     http.Header{},
+				StatusCode: statusCode,
+				Body:       newBody(body),
+			}, nil
+		},
+	}
+}

--- a/proxy/manager.go
+++ b/proxy/manager.go
@@ -31,6 +31,7 @@ func newRootHandler(backendURL string, cache httpcache.Cache) http.Handler {
 
 func newDocumentsHandler(backendURL string, cache httpcache.Cache) http.Handler {
 	cachingTransport := httpcache.NewTransport(cache)
+	cachingTransport.Transport = newDocumentTransport(http.DefaultTransport)
 	httpClient := &http.Client{Transport: cachingTransport}
 
 	return newProxy(newRequestBuilder(backendURL, false), httpClient.Do, forwardResponse)

--- a/proxy/root_transport.go
+++ b/proxy/root_transport.go
@@ -11,8 +11,6 @@ import (
 
 const cacheDuration = 7 * 24 * 60 * 60 // 7 days
 
-type bodyTransformation func(body io.ReadCloser, req *http.Request) (io.ReadCloser, error)
-
 func newRootTransport(inner http.RoundTripper, backendURL string) *rootTransport {
 	return &rootTransport{inner, hostReplacer(backendURL)}
 }


### PR DESCRIPTION
This PR adds the feature of replacing the protocol (from HTTP to HTTPS) of images served by Prismic