### PR TITLE
Fix document response body not being transformed

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -22,6 +22,10 @@ var rootHeaderBlacklist = map[string]struct{}{
 	"Accept-Encoding": struct{}{},
 }
 
+var documentHeaderBlacklist = map[string]struct{}{
+	"Accept-Encoding": struct{}{},
+}
+
 type requestBuilder func(r *http.Request) (*http.Request, error)
 
 type responseForwarder func(w http.ResponseWriter, res *http.Response) error
@@ -85,14 +89,15 @@ func newRequestBuilder(backendURL string, isAPIRoot bool) requestBuilder {
 			return nil, errors.Wrap(err, "failed to create target request")
 		}
 
+		headerBlackList := documentHeaderBlacklist
 		if isAPIRoot {
-			for k, v := range r.Header {
-				if _, blacklisted := rootHeaderBlacklist[k]; !blacklisted {
-					req.Header[k] = v
-				}
+			headerBlackList = rootHeaderBlacklist
+		}
+
+		for k, v := range r.Header {
+			if _, blacklisted := headerBlackList[k]; !blacklisted {
+				req.Header[k] = v
 			}
-		} else {
-			req.Header = r.Header
 		}
 
 		return req, nil

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -183,10 +183,11 @@ func TestProxy(t *testing.T) {
 				So(req.URL.String(), ShouldEqual, "http://target.com/some/prefix/forward-this?paramOne=foo&second=bar")
 			})
 
-			Convey("forwards all headers", func() {
+			Convey("forwards headers that are not black-listed", func() {
 				r := createSourceRequest("http://mysite.com/forward-this", map[string]string{
-					"X-Custom":      "some-value",
-					"Cache-Control": "no-cache",
+					"X-Custom":        "some-value",
+					"Cache-Control":   "no-cache",
+					"Accept-Encoding": "gzip",
 				})
 
 				req, err := buildRequest(r)


### PR DESCRIPTION
In order to apply a transformation to the document body, it cannot be encoded.

I've removed the `Accept-Encoding` header from the request to receive the decoded body, as JSON.