### PR TITLE
fix: use correct invalidation for redis-cluster

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,52 @@ jobs:
       - run: docker login -u ${DOCKER_LOGIN} -p ${DOCKER_PASSWORD}
       - run: ./docker_deploy.sh escaletech/buran
 
+  test-rediscluster:
+    docker:
+      - image: golang:1.13-alpine
+    steps:
+      - checkout
+      - run:
+          name: Start Redis Cluster
+          command: |
+            apk add redis bash make
+            ./scripts/create-cluster start
+            echo "yes\n" | ./scripts/create-cluster create
+      - restore_cache:
+          keys:
+            - go-mod-v1-{{ checksum "go.sum" }}
+      - run: GOOS=linux GOARCH=amd64 CGO_ENABLED=0 make test-rediscluster
+      - save_cache:
+          key: go-mod-v1-{{ checksum "go.sum" }}
+          paths: ["/go/pkg/mod"]
+
+  test-redis:
+    docker:
+      - image: circleci/golang:1.13
+      - image: circleci/redis
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - go-mod-v1-{{ checksum "go.sum" }}
+      - run: make test-redis
+      - save_cache:
+          key: go-mod-v1-{{ checksum "go.sum" }}
+          paths: ["/go/pkg/mod"]
+
+  test-memory:
+    docker:
+      - image: circleci/golang:1.13
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - go-mod-v1-{{ checksum "go.sum" }}
+      - run: make test-memory
+      - save_cache:
+          key: go-mod-v1-{{ checksum "go.sum" }}
+          paths: ["/go/pkg/mod"]
+
 ci_only: &ci_only
   filters:
     tags:
@@ -48,11 +94,28 @@ workflows:
     jobs:
       - build-and-test:
           <<: *ci_only
+      - test-memory:
+          <<: *ci_only
+          requires: [build-and-test]
+      - test-redis:
+          <<: *ci_only
+          requires: [build-and-test]
+      - test-rediscluster:
+          <<: *ci_only
+          requires: [build-and-test]
   release:
     jobs:
       - build-and-test:
           <<: *tags_only
+      - test-memory:
+          <<: *tags_only
+          requires: [build-and-test]
+      - test-redis:
+          <<: *tags_only
+          requires: [build-and-test]
+      - test-rediscluster:
+          <<: *tags_only
+          requires: [build-and-test]
       - deploy:
           <<: *tags_only
-          requires:
-            - build-and-test
+          requires: [test-memory, test-redis, test-rediscluster]

--- a/Makefile
+++ b/Makefile
@@ -13,5 +13,21 @@ build:
 		-o ./dist/buran \
 		./cmd/server
 
-test:
+test-unit:
 	go test -v ./...
+
+test-memory:
+	CACHE_PROVIDER=memory \
+		go test ./cmd/server/handler/** -v
+
+test-redis:
+	CACHE_PROVIDER=redis \
+	REDIS_URL="redis://127.0.0.1:6379" \
+	TTL=432000 \
+		go test ./cmd/server/handler/** -v
+
+test-rediscluster:
+	CACHE_PROVIDER=redis-cluster \
+	REDIS_URL="redis://127.0.0.1:30001" \
+	TTL=432000 \
+		go test ./cmd/server/handler/** -v

--- a/cmd/server/handler/handler.go
+++ b/cmd/server/handler/handler.go
@@ -1,0 +1,40 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/gorilla/handlers"
+	"github.com/gorilla/mux"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+
+	"github.com/escaleseo/buran/internal/cache"
+	"github.com/escaleseo/buran/internal/platform/env"
+	"github.com/escaleseo/buran/internal/platform/logger"
+	"github.com/escaleseo/buran/internal/proxy"
+	"github.com/escaleseo/buran/internal/webhook"
+)
+
+func New(config env.Config, log *logrus.Logger) (http.Handler, error) {
+	cacheProvider, err := cache.NewProvider(config)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get cache provider")
+	}
+
+	proxies, err := proxy.NewManager(config, cacheProvider.GetCache())
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create proxy handler")
+	}
+
+	webhookHandler := webhook.New(cacheProvider)
+
+	router := mux.NewRouter()
+	router.Use(handlers.CORS(handlers.AllowedOrigins([]string{"*"})))
+	router.Use(logger.NewMiddleware())
+	router.Handle("/_webhook", webhookHandler)
+	router.Path("/api/v2").Handler(proxies.Root)
+	router.PathPrefix("/api/v2/documents").Handler(proxies.Documents)
+	router.NewRoute().Handler(proxy.Direct(config.BackendURL))
+
+	return router, nil
+}

--- a/cmd/server/handler/integration_test.go
+++ b/cmd/server/handler/integration_test.go
@@ -1,0 +1,198 @@
+// +build integration
+
+package handler
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/escaleseo/buran/cmd/server/handler"
+	"github.com/escaleseo/buran/internal/platform/env"
+	"github.com/escaleseo/buran/internal/platform/logger"
+	"github.com/kelseyhightower/envconfig"
+	. "github.com/smartystreets/goconvey/convey"
+	"gopkg.in/h2non/gentleman.v2"
+)
+
+func TestHandler(t *testing.T) {
+	var config env.Config
+	envconfig.MustProcess("", &config)
+
+	getEnv := func(t *testing.T) (*TestEnvironment, func()) {
+		te := newEnvironment(t, config)
+		return te, func() {
+			te.Server.Close()
+			te.BackendServer.Close()
+		}
+	}
+
+	Convey(config.CacheProvider+" cache provider", t, func() {
+		Convey("root API call", func() {
+			Convey("returns fresh result", func() {
+				te, tearDown := getEnv(t)
+				defer tearDown()
+
+				be, reqs := handleStatic(200, "ok")
+				te.BackendHandler = be
+
+				// Act
+				res, err := te.Client.Get().AddPath("/api/v2").Do()
+
+				// Assert
+				So(err, ShouldBeNil)
+				So(res.StatusCode, ShouldEqual, 200)
+				So(res.String(), ShouldEqual, "ok")
+				So(len(*reqs), ShouldEqual, 1)
+			})
+
+			Convey("returns cached result without repeating request", func() {
+				te, tearDown := getEnv(t)
+				defer tearDown()
+
+				be, reqs := handleStatic(200, "ok")
+				te.BackendHandler = be
+
+				te.Client.Get().AddPath("/api/v2").Do()
+
+				// Act
+				res, err := te.Client.Get().AddPath("/api/v2").Do()
+
+				// Assert
+				So(err, ShouldBeNil)
+				So(res.StatusCode, ShouldEqual, 200)
+				So(res.String(), ShouldEqual, "ok")
+				So(len(*reqs), ShouldEqual, 1)
+			})
+
+			Convey("returns fresh again after receiving webhook call", func() {
+				te, tearDown := getEnv(t)
+				defer tearDown()
+
+				be, reqs := handleStatic(200, "ok")
+				te.BackendHandler = be
+
+				te.Client.Get().AddPath("/api/v2").Do()
+				te.CallWebhook()
+
+				// Act
+				res, err := te.Client.Get().AddPath("/api/v2").Do()
+
+				// Assert
+				So(err, ShouldBeNil)
+				So(res.StatusCode, ShouldEqual, 200)
+				So(res.String(), ShouldEqual, "ok")
+				So(len(*reqs), ShouldEqual, 2)
+			})
+
+			Convey("makes a new call for each host header variation", func() {
+				te, tearDown := getEnv(t)
+				defer tearDown()
+
+				be, reqs := handleStatic(200, "ok")
+				te.BackendHandler = be
+
+				// Act
+				const reps = 10
+				for i := 0; i < reps; i++ {
+					te.Client.Get().AddPath("/api/v2").
+						SetHeader("X-Forwarded-Host", fmt.Sprintf("host-%v", i)).
+						Do()
+				}
+
+				So(len(*reqs), ShouldEqual, reps)
+			})
+
+			Convey("webhook invalidates every host variation", func() {
+				te, tearDown := getEnv(t)
+				defer tearDown()
+
+				be, reqs := handleStatic(200, "ok")
+				te.BackendHandler = be
+
+				const reps = 10
+				for i := 0; i < reps; i++ {
+					te.Client.Get().AddPath("/api/v2").
+						SetHeader("X-Forwarded-Host", fmt.Sprintf("host-%v", i)).
+						Do()
+				}
+
+				te.CallWebhook()
+
+				// Act
+				for i := 0; i < reps; i++ {
+					te.Client.Get().AddPath("/api/v2").
+						SetHeader("X-Forwarded-Host", fmt.Sprintf("host-%v", i)).
+						Do()
+				}
+
+				So(len(*reqs), ShouldEqual, reps*2)
+			})
+		})
+	})
+}
+
+func handleStatic(code int, body string) (http.HandlerFunc, *[]*http.Request) {
+	reqs := &[]*http.Request{}
+	lock := sync.Mutex{}
+	h := func(w http.ResponseWriter, r *http.Request) {
+		lock.Lock()
+		defer lock.Unlock()
+
+		*reqs = append(*reqs, r)
+
+		w.WriteHeader(code)
+		w.Write([]byte(body))
+	}
+	return h, reqs
+}
+
+func newEnvironment(t *testing.T, config env.Config) *TestEnvironment {
+	log := logger.Get()
+	log.Out = ioutil.Discard
+
+	te := &TestEnvironment{}
+
+	backend := func(w http.ResponseWriter, r *http.Request) {
+		if te.BackendHandler == nil {
+			t.Error("no backend handler configured")
+			t.FailNow()
+		}
+		te.BackendHandler(w, r)
+	}
+	te.BackendServer = httptest.NewServer(http.HandlerFunc(backend))
+	config.BackendURL = te.BackendServer.URL
+
+	h, err := handler.New(config, log)
+	if err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
+
+	te.Server = httptest.NewServer(h)
+	te.Client = gentleman.New().BaseURL(te.Server.URL)
+
+	return te
+}
+
+type TestEnvironment struct {
+	Server         *httptest.Server
+	Client         *gentleman.Client
+	BackendHandler http.HandlerFunc
+	BackendServer  *httptest.Server
+}
+
+func (te *TestEnvironment) CallWebhook() {
+	res, err := te.Client.Post().AddPath("/_webhook").
+		JSON(map[string]interface{}{"type": "api-update"}).
+		Do()
+
+	So(err, ShouldBeNil)
+	So(res.StatusCode, ShouldEqual, 200)
+	if res.StatusCode != 200 {
+		Println("webhook response: ", res.String())
+	}
+}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,45 +1,28 @@
 package main
 
 import (
+	"log"
 	"net/http"
 
-	"github.com/gorilla/handlers"
-	"github.com/gorilla/mux"
-
-	"github.com/escaleseo/buran/internal/cache"
+	"github.com/escaleseo/buran/cmd/server/handler"
 	"github.com/escaleseo/buran/internal/platform/env"
 	"github.com/escaleseo/buran/internal/platform/logger"
-	"github.com/escaleseo/buran/internal/proxy"
-	"github.com/escaleseo/buran/internal/webhook"
 )
 
 func main() {
 	config := env.GetConfig()
+	if config.BackendURL == "" {
+		log.Fatal("missing required BACKEND_URL")
+	}
 
 	log := logger.Get()
-
-	cacheProvider, err := cache.NewProvider(config)
+	h, err := handler.New(config, log)
 	if err != nil {
-		log.WithError(err).Fatal("failed do get cache provider")
+		log.WithError(err).Fatal(err.Error())
 	}
-
-	proxies, err := proxy.NewManager(config, cacheProvider.GetCache())
-	if err != nil {
-		log.WithError(err).Fatal("failed to create proxy handler")
-	}
-
-	webhookHandler := webhook.New(cacheProvider)
-
-	router := mux.NewRouter()
-	router.Use(handlers.CORS(handlers.AllowedOrigins([]string{"*"})))
-	router.Use(logger.NewMiddleware())
-	router.Handle("/_webhook", webhookHandler)
-	router.Path("/api/v2").Handler(proxies.Root)
-	router.PathPrefix("/api/v2/documents").Handler(proxies.Documents)
-	router.NewRoute().Handler(proxy.Direct(config.BackendURL))
 
 	log.Info("listening on port ", config.Port)
-	if err := http.ListenAndServe(":"+config.Port, router); err != nil {
+	if err := http.ListenAndServe(":"+config.Port, h); err != nil {
 		log.WithError(err).Error("server quit")
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/gorilla/mux v1.7.0
 	github.com/gregjones/httpcache v0.0.0-20190203031600-7a902570cb17
 	github.com/kelseyhightower/envconfig v1.3.0
+	github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32 // indirect
 	github.com/onsi/ginkgo v1.12.0 // indirect
 	github.com/onsi/gomega v1.9.0 // indirect
 	github.com/pkg/errors v0.8.1
@@ -14,6 +15,8 @@ require (
 	github.com/sirupsen/logrus v1.3.0
 	github.com/smartystreets/assertions v0.0.0-20190116191733-b6c0e53d7304 // indirect
 	github.com/smartystreets/goconvey v0.0.0-20190731233626-505e41936337
+	golang.org/x/net v0.0.0-20200301022130-244492dfa37a // indirect
+	gopkg.in/h2non/gentleman.v2 v2.0.4
 )
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/kelseyhightower/envconfig v1.3.0 h1:IvRS4f2VcIQy6j4ORGIf9145T/AsUB+oY
 github.com/kelseyhightower/envconfig v1.3.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32 h1:W6apQkHrMkS0Muv8G/TipAy/FJl/rCYT0+EuS8+Z0z4=
+github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32/go.mod h1:9wM+0iRr9ahx58uYLpLIr5fm8diHn0JbqRycJi6w0Ms=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.0 h1:Iw5WCbBcaAAd0fpRb1c9r5YCylv4XDoCSigm1zLevwU=
 github.com/onsi/ginkgo v1.12.0/go.mod h1:oUhWkIvk5aDxtKvDDuw8gItl8pKl42LzjC9KZE0HfGg=
@@ -53,6 +55,8 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a h1:oWX7TPOiFAMXLq8o0ikBYfCJVlRHBcsciT5bXOrH628=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/net v0.0.0-20200301022130-244492dfa37a h1:GuSPYbZzB5/dcLNCwLQLsg3obCJtX9IJhpXkvY7kzk0=
+golang.org/x/net v0.0.0-20200301022130-244492dfa37a/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f h1:wMNYb4v58l5UBM7MYRLPG6ZhfOqbKu7X5eyFl8ZhKvA=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33 h1:I6FyU15t786LL7oL/hn43zqTuEGr4PN7F4XJ1p4E3Y8=
@@ -72,6 +76,8 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
+gopkg.in/h2non/gentleman.v2 v2.0.4 h1:9R3K6CFYd/RdXDLi0pGXwaPnRx/pn5EZlrN3VkNygWc=
+gopkg.in/h2non/gentleman.v2 v2.0.4/go.mod h1:A1c7zwrTgAyyf6AbpvVksYtBayTB4STBUGmdkEtlHeA=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=

--- a/internal/cache/rediscluster/provider.go
+++ b/internal/cache/rediscluster/provider.go
@@ -31,7 +31,7 @@ func New(config env.Config) (*RedisClusterCacheProvider, error) {
 		Addrs: []string{opts.Addr},
 	})
 
-	ttl, err := strconv.Atoi(env.GetConfig().TTL)
+	ttl, err := strconv.Atoi(config.TTL)
 	if err != nil {
 		return nil, errors.Wrap(err, "invalid TTL")
 	}

--- a/internal/platform/env/config.go
+++ b/internal/platform/env/config.go
@@ -6,7 +6,7 @@ import (
 
 type Config struct {
 	Port          string `default:"3000"`
-	BackendURL    string `required:"true" split_words:"true"`
+	BackendURL    string `split_words:"true"`
 	RedisURL      string `default:"redis://localhost" split_words:"true"`
 	CacheProvider string `default:"memory" split_words:"true"`
 	TTL           string `default:"432000"` // five days in seconds

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -111,5 +111,14 @@ func hostVariationParam(r *http.Request) string {
 			proto = k
 		}
 	}
-	return fmt.Sprintf("?%v=%v", HostParamKey, url.QueryEscape(proto+"://"+r.Host))
+
+	host := r.Header.Get("X-Forwarded-Host")
+	if host == "" {
+		host = r.Header.Get("Host")
+	}
+	if host == "" {
+		host = r.Host
+	}
+
+	return fmt.Sprintf("?%v=%v", HostParamKey, url.QueryEscape(proto+"://"+host))
 }

--- a/scripts/create-cluster
+++ b/scripts/create-cluster
@@ -1,0 +1,102 @@
+#!/bin/bash
+
+# Settings
+PORT=30000
+TIMEOUT=2000
+NODES=6
+REPLICAS=1
+
+# You may want to put the above config parameters into config.sh in order to
+# override the defaults without modifying this script.
+
+if [ -a config.sh ]
+then
+    source "config.sh"
+fi
+
+# Computed vars
+ENDPORT=$((PORT+NODES))
+
+if [ "$1" == "start" ]
+then
+    while [ $((PORT < ENDPORT)) != "0" ]; do
+        PORT=$((PORT+1))
+        echo "Starting $PORT"
+        redis-server --port $PORT --cluster-enabled yes --cluster-config-file nodes-${PORT}.conf --cluster-node-timeout $TIMEOUT --appendonly yes --appendfilename appendonly-${PORT}.aof --dbfilename dump-${PORT}.rdb --logfile ${PORT}.log --daemonize yes
+    done
+    exit 0
+fi
+
+if [ "$1" == "create" ]
+then
+    HOSTS=""
+    while [ $((PORT < ENDPORT)) != "0" ]; do
+        PORT=$((PORT+1))
+        HOSTS="$HOSTS 127.0.0.1:$PORT"
+    done
+    redis-cli --cluster create $HOSTS --cluster-replicas $REPLICAS
+    exit 0
+fi
+
+if [ "$1" == "stop" ]
+then
+    while [ $((PORT < ENDPORT)) != "0" ]; do
+        PORT=$((PORT+1))
+        echo "Stopping $PORT"
+        redis-cli -p $PORT shutdown nosave
+    done
+    exit 0
+fi
+
+if [ "$1" == "watch" ]
+then
+    PORT=$((PORT+1))
+    while [ 1 ]; do
+        clear
+        date
+        redis-cli -p $PORT cluster nodes | head -30
+        sleep 1
+    done
+    exit 0
+fi
+
+if [ "$1" == "tail" ]
+then
+    INSTANCE=$2
+    PORT=$((PORT+INSTANCE))
+    tail -f ${PORT}.log
+    exit 0
+fi
+
+if [ "$1" == "call" ]
+then
+    while [ $((PORT < ENDPORT)) != "0" ]; do
+        PORT=$((PORT+1))
+        redis-cli -p $PORT $2 $3 $4 $5 $6 $7 $8 $9
+    done
+    exit 0
+fi
+
+if [ "$1" == "clean" ]
+then
+    rm -rf *.log
+    rm -rf appendonly*.aof
+    rm -rf dump*.rdb
+    rm -rf nodes*.conf
+    exit 0
+fi
+
+if [ "$1" == "clean-logs" ]
+then
+    rm -rf *.log
+    exit 0
+fi
+
+echo "Usage: $0 [start|create|stop|watch|tail|clean]"
+echo "start       -- Launch Redis Cluster instances."
+echo "create      -- Create a cluster using redis-cli --cluster create."
+echo "stop        -- Stop Redis Cluster instances."
+echo "watch       -- Show CLUSTER NODES output (first 30 lines) of first node."
+echo "tail <id>   -- Run tail -f of instance at base port + ID."
+echo "clean       -- Remove all instances data, logs, configs."
+echo "clean-logs  -- Remove just instances logs."


### PR DESCRIPTION
This PR fixes the invalidation for `redis-cluster` provider.

It also adds basic integration tests for each provider, to ensure that they behave the same way.